### PR TITLE
Fix single byte/char edge cases in both encode and decode

### DIFF
--- a/base45/__init__.py
+++ b/base45/__init__.py
@@ -17,15 +17,15 @@ def b45encode(buf: bytes) -> bytes:
         d, c = divmod(x, 45)
         res += BASE45_CHARSET[c] + BASE45_CHARSET[d] + BASE45_CHARSET[e]
     if buflen & 1:
-        i += 2
-        x = buf[i]
-        d, c = divmod(x, 45)
+        d, c = divmod(buf[-1], 45)
         res += BASE45_CHARSET[c] + BASE45_CHARSET[d]
     return res.encode()
 
 
 def b45decode(s: Union[bytes, str]) -> bytes:
     """Decode base45-encoded string to bytes"""
+    if len(s) == 1:
+        raise ValueError("Invalid base45 string")
     res = []
     try:
         if isinstance(s, str):
@@ -39,9 +39,11 @@ def b45decode(s: Union[bytes, str]) -> bytes:
                 if x > 0xFFFF:
                     raise ValueError
                 res.extend(list(divmod(x, 256)))
-            else:
+            elif buflen - i == 2:
                 x = buf[i] + buf[i + 1] * 45
                 res.append(x)
+            else:
+                res.append(buf[i])
         return bytes(res)
     except (ValueError, IndexError, AttributeError):
         raise ValueError("Invalid base45 string")

--- a/test/test_base45.py
+++ b/test/test_base45.py
@@ -1,24 +1,31 @@
+import random
 import unittest
 
 from base45 import b45decode, b45encode
 
 GOOD_DATA = [
     (b"", b""),
+    (b"\x00", b"00"),
+    (b"\x01", b"10"),
+    (b"\x2c", b":0"),
+    (b"\x2d", b"01"),
+    (b"\x07\xe8", b"::0"),
     (b"AB", b"BB8"),
     (b"\xff\xff", b"FGW"),
     (b"Hello!!", b"%69 VD92EX0"),
     (b"base-45", b"UJCLQE7W581"),
     (b"ietf!", b"QED8WEX0"),
-    (b"\x0d\x0e\x0a\x0d\x0c\x00\x0f\x0f\x0e!", b"CT18C1CN1U+1HZ1"),
+    (b"\x0d\x0e\x0a\x0d\x0c\x00\x0f\x0f\x0e\x21", b"CT18C1CN1U+1HZ1"),
     (b"\x00\x00\x00\x00\x00\x00\x00\x00", b"000000000000"),
     (b"\x00\x00\x00\x00\x00\x00\x00", b"00000000000"),
     (
         b"The quick brown fox jumps over the lazy dog",
         b"8UADZCKFEOEDJOD2KC54EM-DX.CH8FSKDQ$D.OE44E5$CS44+8DK44OEC3EFGVCD2",
     ),
+    (bytes("foo © bar 𝌆 baz", "UTF-8"), b"X.C82EIROA44GECH74C-J1/GUJCW2"),
 ]
 
-BAD_BASE45_STRINGS = [b"xyzzy", b"::::", b"a", 42, b"GGW"]
+BAD_BASE45_STRINGS = [b"xyzzy", b"::::", b"a", b"GGW", b":", b"0"]
 
 
 class TestBase45(unittest.TestCase):
@@ -37,9 +44,19 @@ class TestBase45(unittest.TestCase):
             b45encode(42)
 
     def test_decode_bad(self):
+        with self.assertRaises(TypeError):
+            b45decode(42)
         for v in BAD_BASE45_STRINGS:
             with self.assertRaises(ValueError):
                 b45decode(v)
+
+    def test_decode_encoded(self):
+        random.seed(42)
+        for i in range(142):
+            binary = bytes(
+                [random.randint(0, 255) for _ in range(random.randint(0, 142))]
+            )
+            self.assertEqual(binary, b45decode(b45encode(binary)))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This PR fixes single byte encoding issues caused by the use of unbound variable `i` in the odd length case. 
It also adds a corresponding check in the decode function to discard impossible one char long encoded strings.
Tests were added to prevent regression.