### PR TITLE
Do not strip whitespace from decode input

### DIFF
--- a/base45/__init__.py
+++ b/base45/__init__.py
@@ -27,7 +27,7 @@ def b45decode(s: Union[bytes, str]) -> bytes:
     """Decode base45-encoded string to bytes"""
     try:
         if isinstance(s, str):
-            buf = [BASE45_DICT[c] for c in s.strip()]
+            buf = [BASE45_DICT[c] for c in s.rstrip('\n')]
         elif isinstance(s, bytes):
             buf = [BASE45_DICT[c] for c in s.decode()]
         else:


### PR DESCRIPTION
Spaces are a valid character in the base45 encoding. Do
not strip them from input as that causes invalid decodings.
Instead, only strip the trailing newline that would cause
issues in the dictionary lookup.

Signed-off-by: Stefan Nuernberger <kabelfrickler@gmail.com>